### PR TITLE
make version command is always executed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ VERSION:=$(shell cat VERSION)
 
 all: build
 
+.PHONY: version
 version:
 	echo "__version__ = \"${VERSION}\"" > py/pkg/h2o_nitro/version.py
 	echo "__version__ = \"${VERSION}\"" > py/web/h2o_nitro_web/version.py


### PR DESCRIPTION
fix https://github.com/h2oai/nitro/issues/113

`make version` was conflicting with a file name.

-> the `make version` gave:
```
make: `version' is up to date.
```

=> as a result, `make setup` resulted in error