### PR TITLE
build: 🔒Enable and enforce `boringcrypto` experiment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ clean: clean-docs clean-screenshots clean-py clean-web ## Clean everything
 	rm -f py/pkg/h2o_nitro/version.py
 	rm -f py/web/h2o_nitro_web/version.py
 
+setup-cli: export GOEXPERIMENT = boringcrypto
 setup-cli:
 	cd cli && go install cmd/nitro/nitro.go
 

--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -4,8 +4,11 @@ before:
 builds:
   -
     main: ./cmd/nitro
+    ldflags:
+      - -w -X main.build={{.Version}}
     env:
       - CGO_ENABLED=0
+      - GOEXPERIMENT=boringcrypto
     goos:
       - linux
       - windows

--- a/cli/cmd/nitro/nitro.go
+++ b/cli/cmd/nitro/nitro.go
@@ -18,6 +18,14 @@ import (
 	"runtime"
 	"strings"
 
+	// Blank import of "crypto/tls/fipsonly" enforces that only FIPS-approved algorithms
+	// are used for TLS.
+	// Package is only available only when GOEXPERIMENT=boringcrypto is set.
+	// We do not hide the import behind a build tag so that we enforce that the binary is built with
+	// the boring crypto experiment enabled.
+
+	_ "crypto/tls/fipsonly"
+
 	humanize "github.com/dustin/go-humanize"
 	"github.com/google/shlex"
 	"github.com/peterbourgon/ff/v3/ffcli"


### PR DESCRIPTION
`GOEXPERIMENT=boringcrypto` switches `crypto` packages to call BoringCrypto library. It is included as a precompiled object with Go distibution so can be linked to statically.

We want to have all  binaries consistently built this way to get closer to FIPS 140 compliance.

---

I needed to change the ldflags in the `.goreleaser.yaml` as the default contains `-s` and we want to have symbol table preset as it is the only way how can verify that the binary is buit the way we want.

There's no obvious way how the toolchain version is specified so just FYI, `GOEXPERIMENT=boringcrypto` requires atleast Go 1.19.
